### PR TITLE
fix(package): 2.0.14 does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "nt-transmit-transparently": "^1.0.7",
-    "react-native-image-pan-zoom": "^2.0.14"
+    "react-native-image-pan-zoom": "^2.0.9"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
https://www.npmjs.com/package/react-native-image-pan-zoom

Please choose a version of "react-native-image-pan-zoom" from this list: (Use arrow keys)
❯ 2.0.9