### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "author": "ascoders",
   "license": "MIT",
   "dependencies": {
-    "transmit-transparently": "^1.0.0",
     "react-native-image-pan-zoom": "^2.0.16"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "ascoders",
   "license": "MIT",
   "dependencies": {
-    "nt-transmit-transparently": "^1.0.7",
+    "transmit-transparently": "^1.0.0",
     "react-native-image-pan-zoom": "^2.0.16"
   },
   "peerDependencies": {


### PR DESCRIPTION
This project is currently depending on `nt-transmit-transparently`, which has now been renamed to `transmit-transparently`.

I went to make a PR to switch it here, to silence the warning mentioned [here](https://github.com/next-component/common-transmit-transparently/issues/1), but realised this package isn't actually using that dependency anywhere, so it can be removed.