### PR TITLE
fixed bug where no imageurl is passed, and also #70

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ export default class App extends React.Component {
 |renderArrowRight|function<br><br>`() => React.ReactElement<any>`|no|Cutsom right arrow|`() => null`|
 |onSwipeDown|function<br><br>`() => void`|no|Callback for swipe down|`() => null`|
 |disableSwipeDown|boolean|no|Disable swipe down interactions|`false`|
+|footerContainerStyle|object<br><br>`{someStyle: someValue}`|no|custom style props for container that will be holding your footer that you pass|`bottom: 0, position: "absolute", zIndex: 9999 `|
 
 ## Development pattern
 

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -616,7 +616,6 @@ export default class ImageViewer extends React.Component<Props, State> {
           )
       }
     })
-
     const panResponderYPanHandlers = this.state.panResponderY ?
     this.state.panResponderY.panHandlers :
     {}
@@ -653,7 +652,6 @@ export default class ImageViewer extends React.Component<Props, State> {
           {ImageElements}
 
           </Animated.View>
-
           {
             this!.props!.renderIndicator!(
               (this.state.currentShowIndex || 0) + 1,
@@ -669,8 +667,11 @@ export default class ImageViewer extends React.Component<Props, State> {
                 </TouchableOpacity>
               </View>
             )}
-
-          {this!.props!.renderFooter!(this.state.currentShowIndex)}
+          <View
+            style={[{ bottom: 0, position: "absolute", zIndex: 9999 }, this.props.footerContainerStyle]}
+          >
+            {this!.props!.renderFooter!(this.state.currentShowIndex)}
+          </View>
         </Animated.View>
       </Animated.View>
     )

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -617,10 +617,13 @@ export default class ImageViewer extends React.Component<Props, State> {
       }
     })
 
+    const panResponderYPanHandlers = this.state.panResponderY ?
+    this.state.panResponderY.panHandlers :
+    {}
+
     return (
       <Animated.View
-        style={{ zIndex: 9999 }}
-        {...this.state.panResponderY.panHandlers}
+        {...panResponderYPanHandlers}
         style={this.positionY.getLayout()}
       >
         <Animated.View
@@ -658,7 +661,7 @@ export default class ImageViewer extends React.Component<Props, State> {
             )
           }
 
-          {this.props.imageUrls[this.state.currentShowIndex || 0].originSizeKb &&
+          {this.props.imageUrls[this.state.currentShowIndex || 0] && this.props.imageUrls[this.state.currentShowIndex || 0].originSizeKb &&
             this.props.imageUrls[this.state.currentShowIndex || 0].originUrl && (
               <View style={this.styles.watchOrigin}>
                 <TouchableOpacity style={this.styles.watchOriginTouchable}>

--- a/src/image-viewer.type.ts
+++ b/src/image-viewer.type.ts
@@ -39,6 +39,11 @@ export class Props {
   public backgroundColor?: string = "black"
 
   /**
+   * style props for the footer container
+   */
+  public footerContainerStyle?: object = {}
+
+  /**
    * Menu Context Values
    */
   public menuContext?: any = {


### PR DESCRIPTION
This fixes the lib throwing an error for panHandlers and originSizeKb when no imageUrls are passed.

it also removes a unused style object from the Y axis animated view

it also fixes #70 by adding a wrapper around the footer element that ensures that it says at the bottom. I added a prop called `footerContainerStyle`which lets you change the style of this new wrapper.

here's the fix for renderFooter in action:
<img width="365" alt="screen shot 2018-03-19 at 4 49 35 pm" src="https://user-images.githubusercontent.com/11575429/37624303-b055a158-2b95-11e8-8b7d-ebc10f882e0c.png">
