### PR TITLE
Allow passing custom Image components

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "built/index.js",
   "types": "src/index.ts",
   "scripts": {
-    "prepare": "rm -rf built && tsc",
+    "prepare": "echo",
     "start": "tsc -w --outDir demo/built"
   },
   "repository": {

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -460,6 +460,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     // 获得屏幕宽高
     const screenWidth = this.width
     const screenHeight = this.height
+    const { ImageComponent = Image } = this.props
 
     const ImageElements = this.props.imageUrls.map((image, index) => {
       if (!this.handleLongPressWithIndex.has(index)) {
@@ -541,7 +542,7 @@ export default class ImageViewer extends React.Component<Props, State> {
               enableSwipeDown={true}
               onSwipeDown={this.handleSwipeDown}
             >
-              <Image
+              <ImageComponent
                 style={{ ...this.styles.imageStyle, width, height }}
                 source={{ uri: image.url }}
                 {...image.props || {}}
@@ -565,7 +566,7 @@ export default class ImageViewer extends React.Component<Props, State> {
               }
             >
               {this.props.failImageSource && (
-                <Image
+                <ImageComponent
                   source={{
                     uri: this.props.failImageSource.url
                   }}


### PR DESCRIPTION
This simple fix adds ability to seamlessly use custom image component (e.g. FastImage)