### PR TITLE
Allow header component to receive touches

### DIFF
--- a/src/image-viewer.style.ts
+++ b/src/image-viewer.style.ts
@@ -60,6 +60,7 @@ export const simpleStyle: {
     left: 0,
     right: 0,
     top: 38,
+    zIndex: -1,
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'transparent'


### PR DESCRIPTION
Currently, the indicator component is overlapping the header component, so the header component cannot receive touches if a button is placed in it.

Resolves #237 