### PR TITLE
Save image status

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -209,6 +209,7 @@ export default class ImageViewer extends React.Component<Props, State> {
         } catch (newError) {
           // Give up..
           imageStatus.status = 'fail';
+          saveImageSize();
         }
       }
     );


### PR DESCRIPTION
`failImageSource` wasn't being loaded because the image status was never set to 'fail'.