### PR TITLE
renderFooter must return index

### DIFF
--- a/src/image-viewer.type.ts
+++ b/src/image-viewer.type.ts
@@ -134,7 +134,7 @@ export class Props {
   /**
    * 自定义尾部
    */
-  public renderFooter?: (currentIndex?: number) => React.ReactElement<any> = () => {
+  public renderFooter?: (currentIndex: number) => React.ReactElement<any> = () => {
     return null as any;
   };
 


### PR DESCRIPTION
renderFooter function must return the index, either it's used or not, else typescript will give error:
```ts
(parameter) index: number | undefined

Type 'undefined' cannot be used as an index type.ts(2538)
```