### PR TITLE
Prohibit any panResponder when longPress to show menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ export default class App extends React.Component {
 | doubleClickInterval    | number                                                                                 | no       | Double click interval.                                                                                                                                                                                                               |                                                           |
 | pageAnimateTime        | number                                                                                 | no       | Set the animation time for page flipping.                                                                                                                                                                                            | `100`                                                     |
 | enablePreload          | boolean                                                                                | no       | Preload the next image                                                                                                                                                                                                               | `false`                                                   |
-
+| menus                  | function<br><br>`({cancel,saveToLocal}) => React.ReactElement<any>`                    | no       | Custom menus, with 2 methods:`cancel` to hide menus and `saveToLocal` to save image to camera
 ## Development pattern
 
 ### Step 1, run TS listener

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -547,8 +547,9 @@ export default class ImageViewer extends React.Component<Props, State> {
               enableSwipeDown={this.props.enableSwipeDown}
               swipeDownThreshold={this.props.swipeDownThreshold}
               onSwipeDown={this.handleSwipeDown}
-              pinchToZoom={this.props.enableImageZoom}
-              enableDoubleClickZoom={this.props.enableImageZoom}
+              panToMove={!this.state.isShowMenu}
+              pinchToZoom={this.props.enableImageZoom&&!this.state.isShowMenu}
+              enableDoubleClickZoom={this.props.enableImageZoom&&!this.state.isShowMenu}
               doubleClickInterval={this.props.doubleClickInterval}
             >
               {this!.props!.renderImage!(image.props)}

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -642,6 +642,14 @@ export default class ImageViewer extends React.Component<Props, State> {
       return null;
     }
 
+    if(this.props.menus) {
+      return (
+          <View style={this.styles.menuContainer}>
+            {this.props.menus({cancel:this.handleLeaveMenu,saveToLocal:this.saveToLocal})}
+          </View>
+      )
+    }
+
     return (
       <View style={this.styles.menuContainer}>
         <View style={this.styles.menuShadow} />


### PR DESCRIPTION
如题🐶

When I open the menu, Responder still exists in ImageZoom.

See the detail in ⬇️ gif

![5月-18-2019 09-24-03](https://user-images.githubusercontent.com/28673261/57963663-32ee3400-795a-11e9-81db-6709ab673133.gif)