### PR TITLE
Out of bounds index fix: renderFooter currentIndex #322

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -616,7 +616,7 @@ export default class ImageViewer extends React.Component<Props, State> {
               </View>
             )}
           <View style={[{ bottom: 0, position: 'absolute', zIndex: 9 }, this.props.footerContainerStyle]}>
-            {this!.props!.renderFooter!(this.state.currentShowIndex || -1)}
+            {this!.props!.renderFooter!(this.state.currentShowIndex || 0)}
           </View>
         </Animated.View>
       </Animated.View>


### PR DESCRIPTION
Fixes index issue in renderFooter: https://github.com/ascoders/react-native-image-viewer/issues/322