### PR TITLE
Update deprecated lifecycle methods

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -52,25 +52,25 @@ export default class ImageViewer extends React.Component<Props, State> {
     this.init(this.props);
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.index !== this.state.currentShowIndex) {
-      this.setState(
-        {
-          currentShowIndex: nextProps.index
-        },
-        () => {
-          // 立刻预加载要看的图
-          this.loadImage(nextProps.index || 0);
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    if (nextProps.index !== prevState.prevIndexProp) {
+      return { currentShowIndex: nextProps.index, prevIndexProp: nextProps.index };
+    }
+    return null;
+  }
 
-          this.jumpToCurrentImage();
+  public componentDidUpdate(prevProps: Props, prevState: State) {
+    if (prevProps.index !== this.props.index) {
+      // 立刻预加载要看的图
+      this.loadImage(this.props.index || 0);
 
-          // 显示动画
-          Animated.timing(this.fadeAnim, {
-            toValue: 1,
-            duration: 200
-          }).start();
-        }
-      );
+      this.jumpToCurrentImage();
+
+      // 显示动画
+      Animated.timing(this.fadeAnim, {
+        toValue: 1,
+        duration: 200
+      }).start();
     }
   }
 
@@ -97,6 +97,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     this.setState(
       {
         currentShowIndex: nextProps.index,
+        prevIndexProp: nextProps.index || 0,
         imageSizes
       },
       () => {

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -48,7 +48,7 @@ export default class ImageViewer extends React.Component<Props, State> {
 
   private imageRefs: any[] = [];
 
-  public componentWillMount() {
+  public componentDidMount() {
     this.init(this.props);
   }
 

--- a/src/image-viewer.type.ts
+++ b/src/image-viewer.type.ts
@@ -230,6 +230,11 @@ export class State {
   public currentShowIndex?: number = 0;
 
   /**
+   * Used to detect if parent component applied new index prop
+   */
+  public prevIndexProp?: number = 0;
+
+  /**
    * 图片拉取是否完毕了
    */
   public imageLoaded?: boolean = false;


### PR DESCRIPTION
Closes #350 
This PR replaces soon to be deprecated React lifecycle methods with modern counterparts.

## componentWillMount
straightforward fix, just replaced with componentDidMount

## componentWillReceiveProps
This one is a bit tricky.
The big difference between `componentWillReceiveProps` (WRP) and `getDerivedStateFromProps` (DSFP) is that WRP is invoked **ONLY** when props change and DSFP invokes before every render, no matter if it is caused by props or state change.
To replicate WRP with DSFP there are two solutions:
1) mirror the last prop into state
2) invoke setState() in componentDidUpdate

Option number 2 would cause a re-render, so I decided to use option 1.
This is actually recommended way by [Dans Abramov](https://news.ycombinator.com/item?id=16694785) and React core team ([React's docs Updating state based on props](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props) goes into a bit of details about why the decision was made.)

> Yes. Our recommendation is to put such values on the state (like state.prevRow in the blog post example).
> This frees up React to not hold into the whole previous props object in some cases in future versions.
> 
> It’s a bit more verbose but it also solves the problem of prevProps being null on first render (and thus forcing you to write an extra check every time you use this method).

Couple of other guides ([SO Answer](https://stackoverflow.com/a/49618535), [Another guide](https://www.okera.com/blog/replacing-componentwillreceiveprops-with-getderivedstatefromprops/)) also suggest the same solution.

[People](https://github.com/facebook/react/issues/13505) [are](https://github.com/facebook/react/issues/14817) [a](https://github.com/facebook/react/issues/12898) [bit](https://github.com/facebook/react/issues/13008) [pissed](https://cmichel.io/react-just-got-ugly-with-16-4-update/) about it since it forces mirroring of prop inside the state but after couple of hours of research it seems that there is no easier way for it other than setState in `componentDidUpdate` but it will affect performance due to extra re-render cycle.