### PR TITLE
Add compatibility with RN 0.62

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -69,7 +69,8 @@ export default class ImageViewer extends React.Component<Props, State> {
       // 显示动画
       Animated.timing(this.fadeAnim, {
         toValue: 1,
-        duration: 200
+        duration: 200,
+        useNativeDriver: true
       }).start();
     }
   }
@@ -109,7 +110,8 @@ export default class ImageViewer extends React.Component<Props, State> {
         // 显示动画
         Animated.timing(this.fadeAnim, {
           toValue: 1,
-          duration: 200
+          duration: 200,
+          useNativeDriver: true
         }).start();
       }
     );
@@ -304,7 +306,8 @@ export default class ImageViewer extends React.Component<Props, State> {
     this.standardPositionX = this.positionXNumber;
     Animated.timing(this.positionX, {
       toValue: this.positionXNumber,
-      duration: this.props.pageAnimateTime
+      duration: this.props.pageAnimateTime,
+      useNativeDriver: true
     }).start();
 
     const nextIndex = (this.state.currentShowIndex || 0) - 1;
@@ -337,7 +340,8 @@ export default class ImageViewer extends React.Component<Props, State> {
     this.standardPositionX = this.positionXNumber;
     Animated.timing(this.positionX, {
       toValue: this.positionXNumber,
-      duration: this.props.pageAnimateTime
+      duration: this.props.pageAnimateTime,
+      useNativeDriver: true
     }).start();
 
     const nextIndex = (this.state.currentShowIndex || 0) + 1;
@@ -361,7 +365,8 @@ export default class ImageViewer extends React.Component<Props, State> {
     this.positionXNumber = this.standardPositionX;
     Animated.timing(this.positionX, {
       toValue: this.standardPositionX,
-      duration: 150
+      duration: 150,
+      useNativeDriver: true
     }).start();
   }
 

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -70,7 +70,7 @@ export default class ImageViewer extends React.Component<Props, State> {
       Animated.timing(this.fadeAnim, {
         toValue: 1,
         duration: 200,
-        useNativeDriver: true
+        useNativeDriver: false
       }).start();
     }
   }
@@ -111,7 +111,7 @@ export default class ImageViewer extends React.Component<Props, State> {
         Animated.timing(this.fadeAnim, {
           toValue: 1,
           duration: 200,
-          useNativeDriver: true
+          useNativeDriver: false
         }).start();
       }
     );
@@ -307,7 +307,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     Animated.timing(this.positionX, {
       toValue: this.positionXNumber,
       duration: this.props.pageAnimateTime,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
 
     const nextIndex = (this.state.currentShowIndex || 0) - 1;
@@ -341,7 +341,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     Animated.timing(this.positionX, {
       toValue: this.positionXNumber,
       duration: this.props.pageAnimateTime,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
 
     const nextIndex = (this.state.currentShowIndex || 0) + 1;
@@ -366,7 +366,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     Animated.timing(this.positionX, {
       toValue: this.standardPositionX,
       duration: 150,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 


### PR DESCRIPTION
Fixes: https://github.com/ascoders/react-native-image-viewer/issues/388

RN 0.62 requires specify `useNativeDriver`
Instead get warning message:
WARN     Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`