### PR TITLE
Allow to render renderIndicator and renderFooter at the same time

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -603,6 +603,10 @@ export default class ImageViewer extends React.Component<Props, State> {
             </TouchableWithoutFeedback>
           </View>
 
+          <View style={{zIndex: 9}}>
+            {this.props.renderIndicator((this.state.currentShowIndex || 0) + 1, this.props.imageUrls.length)}
+          </View>
+
           <Animated.View
             style={{
               ...this.styles.moveBox,
@@ -612,7 +616,6 @@ export default class ImageViewer extends React.Component<Props, State> {
           >
             {ImageElements}
           </Animated.View>
-          {this!.props!.renderIndicator!((this.state.currentShowIndex || 0) + 1, this.props.imageUrls.length)}
 
           {this.props.imageUrls[this.state.currentShowIndex || 0] &&
             this.props.imageUrls[this.state.currentShowIndex || 0].originSizeKb &&


### PR DESCRIPTION
When I try to add both of them it doesn't render correctly, I saw the same thing happening with renderHeader but decided to fix only renderIndicator. If it's wrong, could you please explain why it doesn't work for me this way.