### PR TITLE
Pass useNativeDriver down to react-native-image-pan-zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "ascoders",
   "license": "MIT",
   "dependencies": {
-    "react-native-image-pan-zoom": "^2.1.12"
+    "react-native-image-pan-zoom": ">=2.1.12"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -485,6 +485,7 @@ export default class ImageViewer extends React.Component<Props, State> {
           pinchToZoom={this.props.enableImageZoom}
           enableDoubleClickZoom={this.props.enableImageZoom}
           doubleClickInterval={this.props.doubleClickInterval}
+          useNativeDriver={this.props.useNativeDriver}
           {...others}
         >
           {children}
@@ -559,6 +560,7 @@ export default class ImageViewer extends React.Component<Props, State> {
               doubleClickInterval={this.props.doubleClickInterval}
               minScale={this.props.minScale}
               maxScale={this.props.maxScale}
+              useNativeDriver={this.props.useNativeDriver}
             >
               {this!.props!.renderImage!(image.props)}
             </ImageZoom>


### PR DESCRIPTION
Follow-up to https://github.com/ascoders/react-native-image-zoom/pull/128 and https://github.com/ascoders/react-native-image-viewer/pull/394

**Important**: This PR assumes that `react-native-image-pan-zoom` will be released with version 3.0.0 (a major version bump), but please edit it to whatever it ends up getting released as.

**警告**：这个 PR 假设新的 react-native-image-pan-zoom 的版号是 3.0.0。如果不是的话，请改！

------

Now that we can specify `useNativeDriver` in `react-native-image-pan-zoom`, we need to pass down the prop to `<ImageZoom />` too.

因为我们加了 useNativeDriver prop，我们也要把它提供给 ImageZoom -- 他也有分别的动画。