### PR TITLE
Made scrolling smooth on Android when parent updates index prop during pan

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -127,7 +127,11 @@ export default class ImageViewer extends React.Component<Props, State> {
    */
   public jumpToCurrentImage() {
     // 跳到当前图的位置
-    this.positionXNumber = this.width * (this.state.currentShowIndex || 0) * (I18nManager.isRTL ? 1 : -1);
+    const newPositionXNumber = this.width * (this.state.currentShowIndex || 0) * (I18nManager.isRTL ? 1 : -1);
+    // 如果已经到位了，不要重复。会打扰现有的 Animation
+    if (newPositionXNumber === this.positionXNumber) return;
+
+    this.positionXNumber = newPositionXNumber;
     this.standardPositionX = this.positionXNumber;
     this.positionX.setValue(this.positionXNumber);
   }

--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -129,6 +129,8 @@ export default class ImageViewer extends React.Component<Props, State> {
     // 跳到当前图的位置
     const newPositionXNumber = this.width * (this.state.currentShowIndex || 0) * (I18nManager.isRTL ? 1 : -1);
     // 如果已经到位了，不要重复。会打扰现有的 Animation
+    // If the position we'd like to set it to is the same, don't set it.
+    // It may interfere with an existing Animation
     if (newPositionXNumber === this.positionXNumber) return;
 
     this.positionXNumber = newPositionXNumber;


### PR DESCRIPTION
## Motivation

When a user releases a photo while panning on Android, the next image isn't smoothly animated in.

## Cause/debugging

1. **Prerequisite**: Use ImageViewer in a controlled way - update the `index` prop from within the `onChange` handler of the parent component
2. The user releases a pan and this starts an animation in `goNext` or `goPrevious`, which also calls the `onChange` handler
2. In the parent's `onChange` callback, the parent updates the `index`. this causes `componentDidUpdate` to call `jumpToCurrentImage`
3. Even though we're already animating to the right image, `jumpToCurrentImage` calls `setValue`, which immediately cancels the animation

## Fix

Make `jumpToCurrentImage` not call `setValue` if it's already animating to the right place

## Testing

In a test app on Android:

| Before | After |
| --- | --- |
| ![Android before pan](https://user-images.githubusercontent.com/2937410/81970498-7cf11080-95d4-11ea-862a-1816a700359f.gif) | ![Android pan after](https://user-images.githubusercontent.com/2937410/81970530-85e1e200-95d4-11ea-8f8a-f23bdea74a00.gif) |


