### PR TITLE
ImageZoom uses useNativeDriver from the props as well

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -485,6 +485,7 @@ export default class ImageViewer extends React.Component<Props, State> {
           pinchToZoom={this.props.enableImageZoom}
           enableDoubleClickZoom={this.props.enableImageZoom}
           doubleClickInterval={this.props.doubleClickInterval}
+          useNativeDriver={!!this.props.useNativeDriver}
           {...others}
         >
           {children}
@@ -559,6 +560,7 @@ export default class ImageViewer extends React.Component<Props, State> {
               doubleClickInterval={this.props.doubleClickInterval}
               minScale={this.props.minScale}
               maxScale={this.props.maxScale}
+              useNativeDriver={!!this.props.useNativeDriver}
             >
               {this!.props!.renderImage!(image.props)}
             </ImageZoom>


### PR DESCRIPTION
`useNativeDriver` prop is applied to `ImageZoom` from the `react-native-image-pan-zoom`