### PR TITLE
Support custom download logic by client

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -133,6 +133,29 @@ export default class ImageViewer extends React.Component<Props, State> {
   }
 
   /**
+   * Used to implement custom download logic by client.
+   * @see IOnLoadCallbacks
+   */
+  public onLoaded(index: number, url: string) {
+    if (index < this.props.imageUrls.length) {
+      this.props.imageUrls[index].url = url
+      this.loadedIndex.delete(index)
+      this.loadImage(index)
+    }
+  }
+
+  /**
+   * Used to implement custom download logic by client.
+   * @see IOnLoadCallbacks
+   */
+  public onFailed(index: number) {
+    if (index < this.props.imageUrls.length) {
+      const imageStatus = { ...this!.state!.imageSizes![index] }
+      imageStatus.status = "fail"
+    }
+  }
+
+  /**
    * 加载图片，主要是获取图片长与宽
    */
   public loadImage(index: number) {
@@ -147,6 +170,13 @@ export default class ImageViewer extends React.Component<Props, State> {
 
     const image = this.props.imageUrls[index];
     const imageStatus = { ...this!.state!.imageSizes![index] };
+
+    // Placeholder detected: Ask client to download the image and provide us the URL (via IOnLoadCallbacks).
+    if (image.url === "" && this.props.onLoad) {
+      imageStatus.status = "loading"
+      this.props.onLoad(index, this)
+      return
+    }
 
     // 保存 imageSize
     const saveImageSize = () => {

--- a/src/image-viewer.type.ts
+++ b/src/image-viewer.type.ts
@@ -10,6 +10,11 @@ interface IOnMove {
   zoomCurrentDistance: number;
 }
 
+interface IOnLoadCallbacks {
+  onLoaded(index: number, url: string): void
+  onFailed(index: number): void
+}
+
 export class Props {
   /**
    * 是否显示
@@ -225,6 +230,13 @@ export class Props {
    * 当图片切换时触发
    */
   public onChange?: (index?: number) => void = () => {
+    //
+  };
+
+  /**
+   * This method can be used to implement custom download logic.
+   */
+  public onLoad?: (index: number, callbacks: IOnLoadCallbacks) => void = () => {
     //
   };
 


### PR DESCRIPTION
This makes it possible for clients to implement their own download logic and provide a local URL to the image once the download is complete.

This is useful when authorization is required to access images, or any scenario where public URLs to your images aren't available.

### Usage

1. Client sets `image.url` to empty string as a placeholder.

2. Client implements `props.onLoad(index, callbacks)` like so:
```
    async onLoad(index, callbacks) {
        try {
            const url = "file://" + (await downloadImage(index))
            callbacks.onLoaded(index, url)
        } catch (e) {
            callbacks.onFailed(index)
        }
    }
```
3. Rock'n'roll!