### PR TITLE
loadImage when going back and forth with arrows

### DIFF
--- a/src/image-viewer.component.tsx
+++ b/src/image-viewer.component.tsx
@@ -311,7 +311,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     }).start();
 
     const nextIndex = (this.state.currentShowIndex || 0) - 1;
-
+    this.loadImage(nextIndex);
     this.setState(
       {
         currentShowIndex: nextIndex
@@ -345,7 +345,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     }).start();
 
     const nextIndex = (this.state.currentShowIndex || 0) + 1;
-
+    this.loadImage(nextIndex);
     this.setState(
       {
         currentShowIndex: nextIndex


### PR DESCRIPTION
When rendering left and right arrows, on tapping the arrow, either `this.goBack()` or `this.goNext()` is called. See current implementation:

```
            <TouchableWithoutFeedback onPress={this.goBack}>
              <View>{this!.props!.renderArrowLeft!()}</View>
            </TouchableWithoutFeedback>
```

However, in `this.goBack` and `this.goNext`,  `this.loadImage` is never called. So no image is shown. This isn't a problem when doing the actual swipe gesture, because when using the swipe gesture, `this.handleHorizontalOuterRangeOffset` is invoked, which calls `this.loadImage`.

So now, pressing the arrows loads the image.