### PR TITLE
Update image-viewer.style.ts (modalContainer backgroundColor is redundant)

### DIFF
--- a/src/image-viewer.style.ts
+++ b/src/image-viewer.style.ts
@@ -8,7 +8,7 @@ export default (
   [x: string]: ViewStyle | TextStyle;
 } => {
   return {
-    modalContainer: { backgroundColor, justifyContent: 'center', alignItems: 'center', overflow: 'hidden' },
+    modalContainer: { backgroundColor: 'transparent', justifyContent: 'center', alignItems: 'center', overflow: 'hidden' },
     watchOrigin: { position: 'absolute', width, bottom: 20, justifyContent: 'center', alignItems: 'center' },
     watchOriginTouchable: {
       paddingLeft: 10,


### PR DESCRIPTION
modalContainer backgroundColor is redundant, because if backgroundColor with alpha (rgba) and loadingRender props are assigned together to ImageViewer, backgroundColor duplicates and applies alpha (rgba) over alpha (rgba) while loadingRender is shown for a while.